### PR TITLE
Bump org.owasp.dependencycheck from 6.5.3 to 7.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'pmd'
     id 'jacoco'
     id 'com.github.johnrengelman.shadow' version '6.1.0'
-    id 'org.owasp.dependencycheck' version '6.5.3'
+    id 'org.owasp.dependencycheck' version '7.0.0'
     id 'nebula.lint' version '17.7.0'
 }
 


### PR DESCRIPTION
Bumps org.owasp.dependencycheck from 6.5.3 to 7.0.0.

---
updated-dependencies:
- dependency-name: org.owasp.dependencycheck
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>